### PR TITLE
Implement hard-coded auto-kick for non-SteamID users to prevent bot griefing/hacking

### DIFF
--- a/LethalAdmin/Patches/ControllerPatch.cs
+++ b/LethalAdmin/Patches/ControllerPatch.cs
@@ -2,17 +2,32 @@
 using HarmonyLib;
 using LethalAdmin.Logging;
 
-namespace LethalAdmin.Patches;
-
-[HarmonyPatch(typeof(PlayerControllerB))]
-public class ControllerPatch
+namespace LethalAdmin.Patches
 {
-    [HarmonyPatch("ConnectClientToPlayerObject")]
-    [HarmonyPostfix]
-    public static void OnPlayerJoin(PlayerControllerB __instance)
-    { 
-        LethalLogger.AddLog(new Log(
-            $"[Connect] {__instance.playerUsername} ({__instance.playerSteamId}@steam) has joined"
-        ));
+    [HarmonyPatch(typeof(PlayerControllerB))]
+    public class ControllerPatch
+    {
+        [HarmonyPatch("ConnectClientToPlayerObject")]
+        [HarmonyPostfix]
+        public static void OnPlayerJoin(PlayerControllerB __instance)
+        {
+            LethalLogger.AddLog(new Log(
+                $"[Connect] {__instance.playerUsername} ({__instance.playerSteamId}@steam) has joined"
+            ));
+
+            if (__instance.playerSteamId == 0)
+            {
+                var playerInfo = new KickBanTools.PlayerInfo
+                {
+                    Username = __instance.playerUsername,
+                    SteamID = __instance.playerSteamId,
+                    Connected = true, // Assuming the player is connected if this method is called
+                    IsPlayerDead = __instance.isPlayerDead
+                    
+                };
+
+                KickBanTools.KickPlayer(playerInfo);
+            }
+        }
     }
 }


### PR DESCRIPTION
Bots and more extreme griefers/hackers join often without steamID's creating the issue that you cannot ban them. They're free to just keep joining after clicking ban/kick.

My solution to this was to just hard code auto-kicking in.

I was originally using the r2modman version of this, and found your Repo.

Depending on your path of development here I think adding a toggle button to the UI is ideal for future sake?

Other suggestions from general usage is to maybe keep last name known for the banned list but other than that this mod makes the game very playable when hosting larger public lobbies.

Thank you for the development so far.


(Image shows that when I start a server a non-steam ID user often player#1-4 or named "nameless" instantly is 'disconnected' after starting the lobby seems to work swimmingly kicking plenty automatically over hours of gameplay)

![image](https://github.com/gamendegamer321/Lethal-Admin/assets/119866693/eceddbde-3ee9-45d9-b690-001ec1d14a6e)
